### PR TITLE
Clean characters ONLY inside CDATA blocks

### DIFF
--- a/src/PrestashopWebServiceLibrary.php
+++ b/src/PrestashopWebServiceLibrary.php
@@ -261,6 +261,19 @@ class PrestashopWebServiceLibrary
     protected function parseXML($response, $suppressExceptions = false)
     {
         if ($response != '') {
+            // Ensure it's UTF-8 encoded properly
+            $xmlString = mb_convert_encoding($response, 'UTF-8', 'UTF-8');
+
+            // Clean characters ONLY inside CDATA blocks (leave XML tags untouched)
+            $xmlString = preg_replace_callback('/<!\[CDATA\[(.*?)\]\]>/su', function ($matches) {
+                $cleaned = preg_replace(
+                    '/[^\x{9}\x{A}\x{D}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}]/u',
+                    '',
+                    $matches[1]
+                );
+                return "<![CDATA[$cleaned]]>";
+            }, $xmlString);
+
             libxml_clear_errors();
             libxml_use_internal_errors(true);
             $xml = simplexml_load_string($response, 'SimpleXMLElement', LIBXML_NOCDATA);


### PR DESCRIPTION
#### What caused this issue?
While consuming XML responses from the PrestaShop Webservice, some responses failed to parse due to invalid characters in the XML, specifically within <![CDATA[...]]> blocks (e.g., product descriptions or meta fields). 

This was caused by characters like:
EN DASH (–)
EM DASH (—)

Smart quotes, emojis, or control characters
These characters are not allowed in XML 1.0 even if they are technically valid UTF-8.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML parsing reliability by cleaning invalid Unicode characters within CDATA sections, reducing the risk of XML parsing errors for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->